### PR TITLE
NilClass, version 0.0.1

### DIFF
--- a/lib/existence.rb
+++ b/lib/existence.rb
@@ -1,0 +1,1 @@
+require 'existence/nil_class'

--- a/lib/existence/nil_class.rb
+++ b/lib/existence/nil_class.rb
@@ -1,0 +1,9 @@
+class NilClass
+  def present?
+    false
+  end
+
+  def blank?
+    true
+  end
+end

--- a/lib/existence/version.rb
+++ b/lib/existence/version.rb
@@ -1,3 +1,3 @@
 module Existence
-  VERSION = '0.0.0'
+  VERSION = '0.0.1'
 end

--- a/test/existence/nil_class_test.rb
+++ b/test/existence/nil_class_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class NilClassTest < Minitest::Test
+  def test_present_returns_false
+    assert_equal false, nil.present?
+  end
+
+  def test_blank_returns_true
+    assert_equal true, nil.blank?
+  end
+end


### PR DESCRIPTION
Expose `present?` and `blank?` to `NilClass`. Bump version to `0.0.1`.