### PR TITLE
Fix gemspec, bump version

### DIFF
--- a/existence.gemspec
+++ b/existence.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |spec|
   spec.summary = 'Exposes present? and blank? to common Ruby classes.'
   spec.author = 'Josh Wetzel'
   spec.license = 'MIT'
+  spec.files = Dir['lib/**/*.rb']
 
   spec.required_ruby_version = '~> 2'
 

--- a/lib/existence/version.rb
+++ b/lib/existence/version.rb
@@ -1,3 +1,3 @@
 module Existence
-  VERSION = '0.0.5'
+  VERSION = '0.0.6'
 end


### PR DESCRIPTION
Fixes https://github.com/joshwetzel/existence/issues/9 and bumps the version to `0.0.6`.